### PR TITLE
10-delete-a-market-vendor

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -11,7 +11,17 @@ class Api::V0::MarketVendorsController < ApplicationController
     end
   end
   
-  
+  def destroy
+    market_vendor = MarketVendor.find_by(market_vendor_params)
+
+    if market_vendor
+      market_vendor.destroy
+      render json: {}, status: 204
+    else 
+      render json: { errors: [{ detail: "No MarketVendor with market_id=#{params[:market_id]} AND vendor_id=#{params[:vendor_id]} exists"}]}, status: :not_found
+    end
+  end
+
   private
 
   def market_vendor_params

--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -16,7 +16,7 @@ class Api::V0::MarketVendorsController < ApplicationController
 
     if market_vendor
       market_vendor.destroy
-      render json: {}, status: 204
+      render json: {}, status: :no_content
     else 
       render json: { errors: [{ detail: "No MarketVendor with market_id=#{params[:market_id]} AND vendor_id=#{params[:vendor_id]} exists"}]}, status: :not_found
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,11 @@ Rails.application.routes.draw do
         resources :vendors, only: [:index]
       end
 
+      delete "/market_vendors", to: "market_vendors#destroy"
+      
       resources :vendors
-      resources :market_vendors, only: [:index, :create, :destroy]
+      resources :market_vendors, only: [:create] 
+  
     end
   end
 end

--- a/spec/requests/api/v0/delete_a_market_vendor_spec.rb
+++ b/spec/requests/api/v0/delete_a_market_vendor_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe "Delete A MarketVendor" do
+  before do
+    markets = create_list(:market, 5)
+    vendors = create_list(:vendor, 5)
+
+    @market_vendors = []
+    5.times do |i|
+      @market_vendors << create(:market_vendor, market: markets[i], vendor: vendors[i])
+    end
+  end
+
+  context "happy path" do
+    it "successfully destroys a MarketVendor" do
+      market_id = @market_vendors.first.market_id
+      vendor_id = @market_vendors.first.vendor_id
+      
+      expect(MarketVendor.count).to eq(5)
+      
+      delete "/api/v0/market_vendors", params: { market_vendor: { market_id: market_id, vendor_id: vendor_id } }
+
+      expect(response).to have_http_status(:no_content)
+      expect(MarketVendor.exists?(@market_vendors.first.id)).to be false
+      expect(MarketVendor.count).to eq(4)
+    end
+  end
+
+  context "sad path" do
+    it "will throw an error if the association does not exist" do
+      market = create(:market)
+      vendor = create(:vendor)
+
+      delete "/api/v0/market_vendors", params: { market_vendor: { market_id: market.id, vendor_id: vendor.id } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v0/delete_a_vendor_spec.rb
+++ b/spec/requests/api/v0/delete_a_vendor_spec.rb
@@ -7,7 +7,7 @@ describe "Delete A Vendor" do
   end
 
   context "happy path - successful destroy" do
-    it "successfully removes a vendor" do
+    it "successfully destroys a vendor" do
       delete "/api/v0/vendors/#{@vendor_id}"
 
       expect(response).to have_http_status(:no_content)


### PR DESCRIPTION
Describe the changes made:

Add destroy function using non-RESTful route for delete that does not require market_id

Necessary checkmarks:

    [x] All Tests are Passing
    [x] Postman tests are Passing
    [x] The code will run locally

Type of change

    [x] New feature
    [] Bug Fix

Implements/Fixes:

    description closes #10 

